### PR TITLE
Organizational changes for Images, Events, and Users

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.GroupSync"
+        android:enableOnBackInvokedCallback="true"
         tools:targetApi="31" >
+
 
         <activity android:name=".ui.auth.LoginActivity">
             <!-- No intent-filter here as it's not the MAIN activity -->

--- a/app/src/main/java/com/example/groupsync/ui/gallery/ImagesFragment.kt
+++ b/app/src/main/java/com/example/groupsync/ui/gallery/ImagesFragment.kt
@@ -26,12 +26,17 @@ class ImagesFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        // Retrieve the event document id from arguments. See
+        // EventDetailsFragment.kt::onCreateView() for more details.
+        val firestoreId = arguments?.getString("firestoreId")
+
         // Get the current user ID
         val userId = FirebaseAuth.getInstance().currentUser?.uid
-
         userId?.let { uid ->
-            // Adjust the database reference to point to the current user's uploads
-            databaseRef = FirebaseDatabase.getInstance().getReference("uploads").child(uid)
+            // Get a database reference to the images under the current event (firestoreId)
+            databaseRef = FirebaseDatabase.getInstance().getReference("uploads").child(firestoreId!!)
+
 
             binding.recyclerView.layoutManager = LinearLayoutManager(context)
             binding.recyclerView.setHasFixedSize(true)
@@ -49,7 +54,8 @@ class ImagesFragment : Fragment() {
                         imageAdapter = ImageAdapter(requireContext(), uploads)
                         binding.recyclerView.adapter = imageAdapter
                     }
-                    binding.progressCircle.setVisibility(View.INVISIBLE);
+                    // TODO: This causes a null pointer exception...
+//                    binding.progressCircle.setVisibility(View.INVISIBLE);
                 }
 
                 override fun onCancelled(databaseError: DatabaseError) {

--- a/app/src/main/java/com/example/groupsync/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/groupsync/ui/home/HomeViewModel.kt
@@ -31,9 +31,11 @@ class HomeViewModel : ViewModel() {
     }
 
     public fun fetchDataFromFirestore() {
+        // Retrieve events that we are a part of.
         val userId = FirebaseAuth.getInstance().currentUser?.uid
+
         db.collection("events")
-            .whereEqualTo("userId", userId)
+            .whereArrayContains("users", userId!!)  // only get events this user is in
             .get()
             .addOnSuccessListener { result ->
                 val eventsList: MutableList<EventMetadata> = mutableListOf()

--- a/app/src/main/java/com/example/groupsync/ui/newevent/NewEventFragment.kt
+++ b/app/src/main/java/com/example/groupsync/ui/newevent/NewEventFragment.kt
@@ -27,9 +27,11 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.StorageTask
 import com.google.firebase.storage.UploadTask
 import com.squareup.picasso.Picasso
@@ -122,28 +124,53 @@ class NewEventFragment : Fragment() {
                         // Create an Upload object with the image URL
                         val upload = Upload(downloadUri.toString())
 
-                        // Note: commented out because we dont want the cover image in the rtdb
-//                        // Store the Upload object in the Firebase Realtime Database
-//                        val uploadId = mDatabaseRef.push().key
-//                        mDatabaseRef.child(uploadId!!).setValue(upload)
-
-                        // Store event data in Firestore with the user ID
+                        // Store event data in firestore and add the current user to it.
+                        // events
+                        // |_   <event_id> (randomly generated)
+                        //      |_  users: uid[]
+                        //      |_  ...
+                        // users
+                        // |_   <uid>
+                        //      |_  events: event_id[]
+                        //      |_  ...
                         userId?.let { uid ->
-                            mFirestoreRef.document().set(
+                            mFirestoreRef.add(
                                 hashMapOf(
-                                    "userId" to uid,
+                                    "creatorUserId" to uid,
+                                    "users" to listOf(uid),
                                     "title" to mTitleField.text.toString(),
                                     "description" to mDescField.text.toString(),
                                     "imageUrl" to downloadUri.toString()
                                 )
-                            ).addOnSuccessListener {
-                                // Navigate back after successful event creation
-                                findNavController().navigateUp()
+                            ).addOnSuccessListener { docRef ->
+                                // We've created the event, now we should add this to the user's
+                                // events.
+                                val usersRef = FirebaseFirestore.getInstance().collection("users")
+                                    .document(uid);
+                                usersRef.set(hashMapOf("events" to FieldValue.arrayUnion(docRef.id)), SetOptions.merge())
+                                    .addOnSuccessListener {
+                                        // Navigate back after successful event creation
+                                        findNavController().navigateUp()
+                                    }
+                                    .addOnFailureListener { e ->
+                                        // Handle failure to store event data in Firestore
+                                        Toast.makeText(
+                                            context,
+                                            "Failed to create event: ${e.message}",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    }
                             }.addOnFailureListener { e ->
                                 // Handle failure to store event data in Firestore
-                                Toast.makeText(context, "Failed to create event: ${e.message}", Toast.LENGTH_SHORT).show()
+                                Toast.makeText(
+                                    context,
+                                    "Failed to create event: ${e.message}",
+                                    Toast.LENGTH_SHORT
+                                ).show()
                             }
                         }
+
+
                     }
                 }
                 .addOnFailureListener { e ->

--- a/app/src/main/java/com/example/groupsync/ui/newevent/NewEventFragment.kt
+++ b/app/src/main/java/com/example/groupsync/ui/newevent/NewEventFragment.kt
@@ -122,13 +122,14 @@ class NewEventFragment : Fragment() {
                         // Create an Upload object with the image URL
                         val upload = Upload(downloadUri.toString())
 
-                        // Store the Upload object in the Firebase Realtime Database
-                        val uploadId = mDatabaseRef.push().key
-                        mDatabaseRef.child(uploadId!!).setValue(upload)
+                        // Note: commented out because we dont want the cover image in the rtdb
+//                        // Store the Upload object in the Firebase Realtime Database
+//                        val uploadId = mDatabaseRef.push().key
+//                        mDatabaseRef.child(uploadId!!).setValue(upload)
 
                         // Store event data in Firestore with the user ID
                         userId?.let { uid ->
-                            mFirestoreRef.document(uploadId).set(
+                            mFirestoreRef.document().set(
                                 hashMapOf(
                                     "userId" to uid,
                                     "title" to mTitleField.text.toString(),


### PR DESCRIPTION
- Images page only shows images for its event.
- Gallery (image upload) page uploads images to its event.
- Events have a "users" list upon creation.
- Only events that include the user in the users list are shown on the home page.

IMPORTANT - New Firebase schemas for this PR:

FIRESTORE
events => <event_id> => ...

![image](https://github.com/Mangr7743/GroupSync/assets/35472865/d3080712-32c3-42ba-8c81-996cea9dc875)
![image](https://github.com/Mangr7743/GroupSync/assets/35472865/b83322bf-bd1e-4de3-8458-3de02560c14c)

REALTIME DATABASE
uploads => <event_id> => imageUrl 

![image](https://github.com/Mangr7743/GroupSync/assets/35472865/d6fe17f4-930c-408d-9159-947d8e4bd0ce)

STORAGE
uploads => <user_id> => x.png
![image](https://github.com/Mangr7743/GroupSync/assets/35472865/03b5c3e1-2b53-40a4-85bf-90b1825e8bd9)
