### PR TITLE
Migrate fragments to activities and add invite codes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.event.EventDetailsActivity"
+            android:exported="true" >
+        </activity>
+
+        <activity
+            android:name=".ui.gallery.GalleryActivity"
+            android:exported="true" >
+        </activity>
+        <activity
+            android:name=".ui.gallery.ImagesActivity"
+            android:exported="true" >
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/groupsync/ui/event/EventDetailsActivity.kt
+++ b/app/src/main/java/com/example/groupsync/ui/event/EventDetailsActivity.kt
@@ -1,39 +1,33 @@
 package com.example.groupsync.ui.event
 
-import android.os.Bundle
-import android.transition.TransitionInflater
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import androidx.navigation.Navigation
-import androidx.navigation.fragment.NavHostFragment.Companion.findNavController
-import androidx.navigation.fragment.findNavController
-import com.example.groupsync.MainActivity
 import com.example.groupsync.R
-import com.example.groupsync.databinding.FragmentEventdetailsBinding
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
+import com.example.groupsync.databinding.ActivityEventdetailsBinding
+import com.example.groupsync.ui.gallery.GalleryActivity
+import com.example.groupsync.ui.gallery.ImagesActivity
 import com.example.groupsync.ui.home.EventMetadata
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.squareup.picasso.Picasso
 
-class EventDetailsFragment : Fragment() {
-    private var _binding: FragmentEventdetailsBinding? = null
-    // This property is only valid between onCreateView and
-    // onDestroyView.
-    private val binding get() = _binding!!
+
+class EventDetailsActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityEventdetailsBinding
 
     private val db = FirebaseFirestore.getInstance()
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         // Inflate the layout for this fragment
-        _binding = FragmentEventdetailsBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        binding = ActivityEventdetailsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        val firestoreId = arguments?.getString("firestoreId")
+        val firestoreId = intent.getStringExtra("firestoreId")
         if (!firestoreId.isNullOrEmpty()) {
             val metadata = fetchFirestoreEventData(firestoreId)
         }
@@ -41,19 +35,29 @@ class EventDetailsFragment : Fragment() {
         // Set up navigation buttons for Gallery and Images
         val bundle = Bundle()
         bundle.putString("firestoreId", firestoreId)
+
+        val mFrag = InviteFragment()
+        mFrag.arguments = bundle
+        val fragmentTransaction = supportFragmentManager.beginTransaction()
+        fragmentTransaction.add(R.id.invite_container, mFrag)
+        fragmentTransaction.commit()
+
         binding.galleryButton.setOnClickListener{
-            findNavController().navigate(R.id.nav_gallery, bundle)
+            val intent: Intent = Intent(
+                this,
+                GalleryActivity::class.java
+            )
+            intent.putExtra("args", bundle)
+            startActivity(intent)
         }
         binding.imagesButton.setOnClickListener{
-            findNavController().navigate(R.id.nav_images, bundle)
+            val intent: Intent = Intent(
+                this,
+                ImagesActivity::class.java
+            )
+            intent.putExtra("args", bundle)
+            startActivity(intent)
         }
-
-        return root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun fetchFirestoreEventData(id: String) {
@@ -72,7 +76,7 @@ class EventDetailsFragment : Fragment() {
                                 document.data?.get("imageUrl").toString()
                             )
 
-                            (activity as MainActivity).supportActionBar?.title = metadata.title
+                            supportActionBar?.title = metadata.title
                             binding.detailsTitle.text = metadata.title
                             binding.detailsDesc.text = metadata.subtitle
                             Picasso.get().load(metadata.image).into(binding.detailsImage)

--- a/app/src/main/java/com/example/groupsync/ui/event/InviteFragment.kt
+++ b/app/src/main/java/com/example/groupsync/ui/event/InviteFragment.kt
@@ -1,0 +1,95 @@
+package com.example.groupsync.ui.event
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat.getSystemService
+import androidx.fragment.app.Fragment
+import com.example.groupsync.databinding.FragmentInviteBinding
+import com.example.groupsync.ui.home.EventMetadata
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+
+
+class InviteFragment : Fragment() {
+    private var _binding: FragmentInviteBinding? = null
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    private val db = FirebaseFirestore.getInstance()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // Inflate the layout for this fragment
+        _binding = FragmentInviteBinding.inflate(inflater, container, false)
+        val root: View = binding.root
+
+        val firestoreId = arguments?.getString("firestoreId")
+        if (!firestoreId.isNullOrEmpty()) {
+            val metadata = fetchFirestoreEventData(firestoreId)
+        }
+
+        binding.copyButton.setOnClickListener { onCodeCopied() }
+        binding.shareButton.setOnClickListener { onCodeShared() }
+
+        return root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun fetchFirestoreEventData(id: String) {
+        val userId = FirebaseAuth.getInstance().currentUser?.uid
+        if (userId != null) {
+            db.collection("events")
+                .whereEqualTo("userId", userId)
+                .get()
+                .addOnSuccessListener { querySnapshot ->
+                    for (document in querySnapshot.documents) {
+                        if (document.id == id) {
+                            val metadata = EventMetadata(
+                                id = id,
+                                inviteCode = document.data?.get("inviteCode").toString()
+                            )
+
+                            binding.inviteCode.text = metadata.inviteCode
+                            return@addOnSuccessListener // Exit the loop after finding the matching document
+                        }
+                    }
+                }
+                .addOnFailureListener { e ->
+                    // Handle failure to fetch event data
+                }
+        }
+    }
+
+    private fun onCodeCopied() {
+        val code = binding.inviteCode.text
+
+        val clipboard = getSystemService(requireContext(), ClipboardManager::class.java) as ClipboardManager
+        val clip = ClipData.newPlainText("Invite Code", code)
+        clipboard.setPrimaryClip(clip)
+    }
+
+    private fun onCodeShared() {
+        val code = "Join my event on GroupSync! Here's the code: ${binding.inviteCode.text}"
+        val sendIntent: Intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, code)
+            type = "text/plain"
+        }
+
+        val shareIntent = Intent.createChooser(sendIntent, null)
+        startActivity(shareIntent)
+    }
+}

--- a/app/src/main/java/com/example/groupsync/ui/gallery/GalleryActivity.kt
+++ b/app/src/main/java/com/example/groupsync/ui/gallery/GalleryActivity.kt
@@ -1,0 +1,18 @@
+package com.example.groupsync.ui.gallery
+
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.example.groupsync.databinding.ActivityGalleryBinding
+
+class GalleryActivity: AppCompatActivity() {
+    private lateinit var binding: ActivityGalleryBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGalleryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+
+    }
+}

--- a/app/src/main/java/com/example/groupsync/ui/gallery/ImagesActivity.kt
+++ b/app/src/main/java/com/example/groupsync/ui/gallery/ImagesActivity.kt
@@ -1,0 +1,18 @@
+package com.example.groupsync.ui.gallery
+
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.example.groupsync.databinding.ActivityImagesBinding
+
+class ImagesActivity: AppCompatActivity() {
+    private lateinit var binding: ActivityImagesBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityImagesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+
+    }
+}

--- a/app/src/main/java/com/example/groupsync/ui/home/EventMetadata.kt
+++ b/app/src/main/java/com/example/groupsync/ui/home/EventMetadata.kt
@@ -1,8 +1,12 @@
 package com.example.groupsync.ui.home
 
-data class EventMetadata(val id: String = "", val title: String = "", val subtitle: String = "", val image: String = "") {
+import android.hardware.biometrics.BiometricManager.Strings
+
+data class EventMetadata(val id: String = "", val title: String = "", val subtitle: String = "", val image: String = "", val inviteCode: String = "", val users: List<String> = listOf() ) {
     private var mId: String? = id
     private var mTitle: String? = title
     private var mSubtitle: String? = subtitle
     private var mCoverImage: String? = image
+    private var mInviteCode: String? = inviteCode
+    private var mUsers: List<String>? = users
 }

--- a/app/src/main/java/com/example/groupsync/ui/home/EventsAdapter.kt
+++ b/app/src/main/java/com/example/groupsync/ui/home/EventsAdapter.kt
@@ -1,14 +1,15 @@
 package com.example.groupsync.ui.home
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.navigation.Navigation.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.example.groupsync.R
+import com.example.groupsync.ui.event.EventDetailsActivity
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.imageview.ShapeableImageView
 import com.squareup.picasso.Picasso
@@ -28,11 +29,10 @@ class EventsAdapter(private val mContext: Context, private val mEvents: List<Eve
         // Convert image url to bitmap
         Picasso.get().load(eventCurrent.image).into(holder.coverImageView)
 
-        val bundle = Bundle()
-        bundle.putString("firestoreId", eventCurrent.id)
-
         holder.containerView.setOnClickListener {
-            findNavController(holder.itemView).navigate(R.id.nav_eventdetails, bundle)
+            val intent = Intent(mContext, EventDetailsActivity::class.java)
+            intent.putExtra("firestoreId", eventCurrent.id)
+            mContext.startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/example/groupsync/ui/newevent/NewEventFragment.kt
+++ b/app/src/main/java/com/example/groupsync/ui/newevent/NewEventFragment.kt
@@ -33,6 +33,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.StorageTask
 import com.google.firebase.storage.UploadTask
 import com.squareup.picasso.Picasso
+import kotlin.random.Random
 
 class NewEventFragment : Fragment() {
     private var _binding: FragmentNeweventBinding? = null
@@ -126,6 +127,12 @@ class NewEventFragment : Fragment() {
                         val uploadId = mDatabaseRef.push().key
                         mDatabaseRef.child(uploadId!!).setValue(upload)
 
+                        val charPool : List<Char> = ('A'..'Z') + ('0'..'9')
+
+                        val inviteCode = (1..6)
+                            .map { Random.nextInt(0, charPool.size).let { charPool[it] } }
+                            .joinToString("")
+
                         // Store event data in Firestore with the user ID
                         userId?.let { uid ->
                             mFirestoreRef.document(uploadId).set(
@@ -133,7 +140,9 @@ class NewEventFragment : Fragment() {
                                     "userId" to uid,
                                     "title" to mTitleField.text.toString(),
                                     "description" to mDescField.text.toString(),
-                                    "imageUrl" to downloadUri.toString()
+                                    "imageUrl" to downloadUri.toString(),
+                                    "inviteCode" to inviteCode,
+                                    "users" to listOf(uid)
                                 )
                             ).addOnSuccessListener {
                                 // Navigate back after successful event creation

--- a/app/src/main/res/layout/activity_eventdetails.xml
+++ b/app/src/main/res/layout/activity_eventdetails.xml
@@ -2,10 +2,12 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/details_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <LinearLayout
+        android:id="@+id/details_inner"
         android:layout_width="409dp"
         android:layout_height="729dp"
         android:layout_marginTop="64dp"
@@ -23,7 +25,7 @@
                 android:id="@+id/details_image"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scaleType="centerCrop"/>
+                android:scaleType="centerCrop" />
         </FrameLayout>
 
         <TextView
@@ -42,17 +44,46 @@
             android:textAlignment="center"
             android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
 
-        <Button
-            android:id="@+id/gallery_button"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Gallery" />
+            android:layout_height="wrap_content">
 
-        <Button
-            android:id="@+id/images_button"
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <Button
+                    android:id="@+id/gallery_button"
+                    android:layout_width="128dp"
+                    android:layout_height="wrap_content"
+                    android:text="Gallery" />
+
+                <Space
+                    android:layout_width="8dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0" />
+
+                <Button
+                    android:id="@+id/images_button"
+                    android:layout_width="128dp"
+                    android:layout_height="wrap_content"
+                    android:text="Images" />
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <FrameLayout
+            android:id="@+id/invite_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Images" />
+            android:layout_height="wrap_content">
+
+        </FrameLayout>
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_gallery.xml
+++ b/app/src/main/res/layout/activity_gallery.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/gallery_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:name="com.example.groupsync.ui.gallery.GalleryFragment" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_images.xml
+++ b/app/src/main/res/layout/activity_images.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/gallery_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:name="com.example.groupsync.ui.gallery.ImagesFragment" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/gallery_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"

--- a/app/src/main/res/layout/fragment_invite.xml
+++ b/app/src/main/res/layout/fragment_invite.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center|center_horizontal|center_vertical"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:outlineProvider="bounds"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <Space
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/inviteCode"
+        style="@style/TextAppearance.Material3.HeadlineMedium"
+        android:layout_width="172dp"
+        android:layout_height="87dp"
+        android:gravity="center_vertical"
+        android:letterSpacing="0.1"
+        android:text="TextView"
+        android:textAlignment="center"
+        android:textAllCaps="true"
+        android:textStyle="normal|bold" />
+
+    <Space
+        android:layout_width="8dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="0" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/copyButton"
+        android:layout_width="60dp"
+        android:layout_height="72dp"
+        android:textAlignment="viewStart"
+        app:icon="?attr/actionModeCopyDrawable"
+        app:iconGravity="textStart"
+        app:iconSize="32dp"
+        app:shapeAppearance="@style/ShapeAppearance.Material3.Corner.Medium" />
+
+    <Space
+        android:layout_width="8dp"
+        android:layout_height="wrap_content" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/shareButton"
+        android:layout_width="60dp"
+        android:layout_height="72dp"
+        android:textAlignment="viewStart"
+        app:icon="?attr/actionModeShareDrawable"
+        app:iconGravity="start|textStart"
+        app:iconPadding="8dp"
+        app:iconSize="32dp"
+        app:shapeAppearance="@style/ShapeAppearance.Material3.Corner.Medium" />
+
+    <Space
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -3,6 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/action_settings"
         android:title="@string/action_settings"
+        android:orderInCategory="200"
+        app:showAsAction="never" />
+    <item android:id="@+id/action_join_event"
+        android:title="@string/join_event"
         android:orderInCategory="100"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -30,17 +30,6 @@
         android:label="@string/menu_newevent"
         tools:layout="@layout/fragment_newevent" />
 
-    <fragment
-        android:id="@+id/nav_eventdetails"
-        android:name="com.example.groupsync.ui.event.EventDetailsFragment"
-        android:label="@string/menu_eventdetails"
-        tools:layout="@layout/fragment_eventdetails">
-        <argument
-            android:name="firestoreId"
-            app:argType="string"
-            android:defaultValue=""/>
-    </fragment>
-
     <!-- New fragment for the calendar page -->
     <fragment
         android:id="@+id/nav_calendar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="login">Login</string>
     <string name="register">Register</string>
     <string name="menu_eventdetails">Event Details</string>
+    <string name="join_event">Join Event</string>
 </resources>


### PR DESCRIPTION
Added invite code schema to firebase. With [Matthews's PR](https://github.com/Mangr7743/GroupSync/pull/9) the firestore schema appears as follows:

![image](https://github.com/Mangr7743/GroupSync/assets/35475826/463aa107-96fa-4ee2-b8aa-f6ba49d70dc4)

where inviteCode is a 6 digit UUID.

Added a fragment that appears on the event detail screen where the invite code can be copied and shared. Integrated with Android clipboard and sharesheet services.
![image](https://github.com/Mangr7743/GroupSync/assets/35475826/b15fe0ba-08c5-40b4-beb9-6d52375d0d21)


Migrated some fragments such as Gallery, Images, and Event Details to Activities. This follows Android development practices more closely and gives us material animations/better backstack handling when we transition between screens.